### PR TITLE
spaces class updated and linked to user id

### DIFF
--- a/lib/spaces.rb
+++ b/lib/spaces.rb
@@ -2,12 +2,12 @@ require_relative 'db_connection'
 
 
 class Spaces
-  attr_reader :id, :name, :des, :price, :user_id
+  attr_reader :id, :name, :description, :price, :user_id
 
-  def initialize(id, name, des, price, user_id)
+  def initialize(id, name, description, price, user_id)
     @id  = id
     @name = name
-    @des = des
+    @description = description
     @price = price
     @user_id = user_id
   end
@@ -15,17 +15,13 @@ class Spaces
   def self.all
       result = DBConnection.query("SELECT * FROM spaces")
       result.map do|space| 
-        Spaces.new(space['space_id'], space['name'], space['description'], space['price'])
+        Spaces.new(space['space_id'], space['name'], space['description'], space['price'], space['user_id'])
       end
   end
 
-  def self.find(id:)
-  end
-
-  def self.create(name, des, price, user_id)
-    #@user = User.instance
+  def self.create(name, description, price, user_id)
     result = DBConnection.query("INSERT INTO spaces (name, description, price, user_id) 
-    VALUES('#{name}', '#{des}', '#{price}', '#{user_id}') RETURNING space_id, name, description, price, user_id;")
+    VALUES('#{name}', '#{description}', '#{price}', '#{user_id}') RETURNING space_id, name, description, price, user_id;")
     Spaces.new(result[0]['space_id'], result[0]['name'], result[0]['description'], result[0]['price'], result[0]['user_id'])
   end 
 end

--- a/lib/spaces.rb
+++ b/lib/spaces.rb
@@ -1,13 +1,15 @@
 require_relative 'db_connection'
 
-class Spaces
-  attr_reader :id, :name, :des, :price
 
-  def initialize(id, name, des, price)
+class Spaces
+  attr_reader :id, :name, :des, :price, :user_id
+
+  def initialize(id, name, des, price, user_id)
     @id  = id
     @name = name
     @des = des
     @price = price
+    @user_id = user_id
   end
 
   def self.all
@@ -20,9 +22,10 @@ class Spaces
   def self.find(id:)
   end
 
-  def self.create(name:, des:, price:)
-    result = DBConnection.query("INSERT INTO spaces (name, description, price) 
-    VALUES('#{name}', '#{des}', '#{price}') RETURNING space_id, name, description, price;")
-    Spaces.new(result[0]['space_id'], result[0]['name'], result[0]['description'], result[0]['price'])
+  def self.create(name, des, price, user_id)
+    #@user = User.instance
+    result = DBConnection.query("INSERT INTO spaces (name, description, price, user_id) 
+    VALUES('#{name}', '#{des}', '#{price}', '#{user_id}') RETURNING space_id, name, description, price, user_id;")
+    Spaces.new(result[0]['space_id'], result[0]['name'], result[0]['description'], result[0]['price'], result[0]['user_id'])
   end 
 end

--- a/lib/spaces.rb
+++ b/lib/spaces.rb
@@ -12,16 +12,20 @@ class Spaces
     @user_id = user_id
   end
 
+  def self.current
+    @space
+  end
+
   def self.all
-      result = DBConnection.query("SELECT * FROM spaces")
-      result.map do|space| 
-        Spaces.new(space['space_id'], space['name'], space['description'], space['price'], space['user_id'])
-      end
+    result = DBConnection.query("SELECT * FROM spaces")
+    result.map do|space| 
+      Spaces.new(space['space_id'], space['name'], space['description'], space['price'], space['user_id'])
+    end
   end
 
   def self.create(name, description, price, user_id)
     result = DBConnection.query("INSERT INTO spaces (name, description, price, user_id) 
     VALUES('#{name}', '#{description}', '#{price}', '#{user_id}') RETURNING space_id, name, description, price, user_id;")
-    Spaces.new(result[0]['space_id'], result[0]['name'], result[0]['description'], result[0]['price'], result[0]['user_id'])
+    @space = Spaces.new(result[0]['space_id'], result[0]['name'], result[0]['description'], result[0]['price'], result[0]['user_id'])
   end 
 end

--- a/spec/feature/viewing_spaces_spec.rb
+++ b/spec/feature/viewing_spaces_spec.rb
@@ -1,6 +1,8 @@
 feature 'Viewing spaces' do
   scenario 'A user can see spaces' do
-    Spaces.create(name: 'Blessing Apartment', des: 'Beautiful three bedroom house', price: "500")
+    # test needs updating - will need to add a user so a user id can be passed
+    # the following line isn't feature testing?
+    Spaces.create('Blessing Apartment', 'Beautiful three bedroom house', "500")
     visit('/spaces')
     expect(page).to have_content('Blessing Apartment')
     expect(page).to have_content('Beautiful three bedroom house')

--- a/spec/unit/space_spec.rb
+++ b/spec/unit/space_spec.rb
@@ -3,39 +3,29 @@ require 'spaces'
 describe Spaces do
   describe '.all' do
     it 'returns all spaces' do
-      # connection = PG.connect(dbname: 'makersbnb_test')
-      # connection.exec("INSERT INTO spaces (name, description, price) VALUES ('Blessing Apartment', 'Beautiful three bedroom house', '500');")
-      # connection.exec("INSERT INTO spaces (name, description, price) VALUES ('Another Apartment', 'Beautiful four bedroom house', '400');")
-      
-      p Spaces.create('Blessing Apartment', 'Beautiful three bedroom house', "500")
-
-      # p DBConnection.query('SELECT * FROM spaces')
-      
+      User.create("john", "john@email.com", "Password")
+      Spaces.create('Blessing Apartment', 'Beautiful three bedroom house', "500", User.current.id)
+      Spaces.create('Blessing Apartment 2', 'Beautiful four bedroom house', "600", User.current.id)
       spaces = Spaces.all
-    
       expect(spaces.length).to eq 2
       expect(spaces.first).to be_a Spaces
-      # expect(spaces.first.id).to eq spaces.id
       expect(spaces.first.name).to eq 'Blessing Apartment'
-      expect(spaces.last.name).to eq 'Another Apartment'
-      expect(spaces.first.des).to eq 'Beautiful three bedroom house'
-      # expect(spaces.first.price).to eq '500'
+      expect(spaces.last.name).to eq 'Blessing Apartment 2'
+      expect(spaces.first.description).to eq 'Beautiful three bedroom house'
+      expect(spaces.last.price).to eq '600'
     end
   end
-end
-
 
 describe '.create' do
   it 'creates a new space' do
-    spaces = Spaces.create(name: 'Tosin Bed & Breakfast', des: 'Beautiful all in one house', price: '300')
-    p spaces
-    # expect(spaces['name']).to eq 'Tosin Bed & Breakfast'
-    # expect(spaces['description']).to eq 'Beautiful all in one house'
-
+    User.create("john", "john@email.com", "Password")
+    spaces = Spaces.create('Tosin Bed & Breakfast', 'Beautiful all in one house', '300', User.current.id)
     expect(spaces).to be_a Spaces
-    # expect(spaces.id).to eq persisted_data.first['id']
     expect(spaces.name).to eq 'Tosin Bed & Breakfast'
-    expect(spaces.des).to eq 'Beautiful all in one house'
-    # expect(spaces[price]).to eq '300'
+    expect(spaces.description).to eq 'Beautiful all in one house'
+    expect(spaces.price).to eq '300'
+    expect(spaces.id.to_i).to be_a Integer
   end
+end
+
 end

--- a/spec/unit/space_spec.rb
+++ b/spec/unit/space_spec.rb
@@ -16,16 +16,23 @@ describe Spaces do
     end
   end
 
-describe '.create' do
-  it 'creates a new space' do
-    User.create("john", "john@email.com", "Password")
-    spaces = Spaces.create('Tosin Bed & Breakfast', 'Beautiful all in one house', '300', User.current.id)
-    expect(spaces).to be_a Spaces
-    expect(spaces.name).to eq 'Tosin Bed & Breakfast'
-    expect(spaces.description).to eq 'Beautiful all in one house'
-    expect(spaces.price).to eq '300'
-    expect(spaces.id.to_i).to be_a Integer
+  describe '.create' do
+    it 'creates a new space object with required parameters' do
+      User.create("john", "john@email.com", "Password")
+      spaces = Spaces.create('Tosin Bed & Breakfast', 'Beautiful all in one house', '300', User.current.id)
+      expect(spaces).to be_a Spaces
+      expect(spaces.name).to eq 'Tosin Bed & Breakfast'
+      expect(spaces.description).to eq 'Beautiful all in one house'
+      expect(spaces.price).to eq '300'
+      expect(spaces.id.to_i).to be_a Integer
+    end
   end
-end
+
+  describe '.current' do
+    it 'returns the current instance of space class' do
+      user = User.create("john", "john@email.com", "Password")
+      expect(User.current.name).to eq 'john' 
+    end
+  end
 
 end

--- a/spec/unit/space_userid_spec.rb
+++ b/spec/unit/space_userid_spec.rb
@@ -1,9 +1,10 @@
 require 'spaces'
 
 describe Spaces do
+  
   it "check if space include the user id" do
     User.create("john", "john@email.com", "Password")
-    user = User.instance
+    user = User.current
     space = Spaces.create("MakersBnb", "comfortable", 250, user.id)
     expect(space.user_id).to eq user.id
 

--- a/spec/unit/space_userid_spec.rb
+++ b/spec/unit/space_userid_spec.rb
@@ -1,0 +1,12 @@
+require 'spaces'
+
+describe Spaces do
+  it "check if space include the user id" do
+    User.create("john", "john@email.com", "Password")
+    user = User.instance
+    space = Spaces.create("MakersBnb", "comfortable", 250, user.id)
+    expect(space.user_id).to eq user.id
+
+  end
+
+end


### PR DESCRIPTION
new space instances now require an extra parameter - user_id

class methods:

spaces.all
spaces.create(name, description, price, user_id)
spaces.current

please note I have removed the symbols from the spaces.create parameters - some of the front end might need refactoring to accommodate this.

some of the feature tests for space are now broken too, I've commented on one of them why this is the case.

